### PR TITLE
fix base64 code in nbformat.v2

### DIFF
--- a/IPython/nbformat/v2/nbjson.py
+++ b/IPython/nbformat/v2/nbjson.py
@@ -16,9 +16,8 @@ Authors:
 # Imports
 #-----------------------------------------------------------------------------
 
-from base64 import encodestring
 from .nbbase import from_dict
-from .rwbase import NotebookReader, NotebookWriter, base64_decode
+from .rwbase import NotebookReader, NotebookWriter, restore_bytes
 import json
 
 #-----------------------------------------------------------------------------
@@ -26,9 +25,10 @@ import json
 #-----------------------------------------------------------------------------
 
 class BytesEncoder(json.JSONEncoder):
+    """A JSON encoder that accepts b64 (and other *ascii*) bytestrings."""
     def default(self, obj):
         if isinstance(obj, bytes):
-            return encodestring(obj).decode('ascii')
+            return obj.decode('ascii')
         return json.JSONEncoder.default(self, obj)
 
 
@@ -40,7 +40,7 @@ class JSONReader(NotebookReader):
         return nb
 
     def to_notebook(self, d, **kwargs):
-        return base64_decode(from_dict(d))
+        return restore_bytes(from_dict(d))
 
 
 class JSONWriter(NotebookWriter):

--- a/IPython/nbformat/v2/tests/nbexamples.py
+++ b/IPython/nbformat/v2/tests/nbexamples.py
@@ -1,10 +1,15 @@
+import os
+from base64 import encodestring
+
 from ..nbbase import (
     NotebookNode,
     new_code_cell, new_text_cell, new_worksheet, new_notebook, new_output,
     new_metadata, new_author
 )
 
-
+# some random base64-encoded *bytes*
+png = encodestring(os.urandom(5))
+jpeg = encodestring(os.urandom(6))
 
 ws = new_worksheet(name='worksheet1')
 
@@ -42,8 +47,8 @@ ws.cells.append(new_code_cell(
         output_text=u'<array a>',
         output_html=u'The HTML rep',
         output_latex=u'$a$',
-        output_png=b'data',
-        output_jpeg=b'data',
+        output_png=png,
+        output_jpeg=jpeg,
         output_svg=u'<svg>',
         output_json=u'json data',
         output_javascript=u'var i=0;',
@@ -53,8 +58,8 @@ ws.cells.append(new_code_cell(
         output_text=u'<array a>',
         output_html=u'The HTML rep',
         output_latex=u'$a$',
-        output_png=b'data',
-        output_jpeg=b'data',
+        output_png=png,
+        output_jpeg=jpeg,
         output_svg=u'<svg>',
         output_json=u'json data',
         output_javascript=u'var i=0;'


### PR DESCRIPTION
base64 encoding functions were called, but had no effect, because
the notebook already has everything as b64-encoded bytestrings, which
are valid ascii literals on Python 2.

However, the encode/decode logic is actually triggered on Python 3, revealing its errors.

This fixes the base64 functions that had no effect to have their intended effect,
but does not use them.  Rather, it is assumed that
bytes objects are already b64-encoded (and thus ascii-safe), which
assumption was already made in Python 2.
