### PR TITLE
Default profile

### DIFF
--- a/IPython/core/magic.py
+++ b/IPython/core/magic.py
@@ -527,7 +527,11 @@ Currently the magic system has the following functions:\n"""
 
     def magic_profile(self, parameter_s=''):
         """Print your currently active IPython profile."""
-        print self.shell.profile
+        from IPython.core.application import BaseIPythonApplication
+        if BaseIPythonApplication.initialized():
+            print BaseIPythonApplication.instance().profile
+        else:
+            error("profile is an application-level value, but you don't appear to be in an IPython application")
 
     def magic_pinfo(self, parameter_s='', namespaces=None):
         """Provide detailed information about an object.

--- a/IPython/zmq/ipkernel.py
+++ b/IPython/zmq/ipkernel.py
@@ -64,6 +64,7 @@ class Kernel(Configurable):
 
     shell = Instance('IPython.core.interactiveshell.InteractiveShellABC')
     session = Instance(Session)
+    profile_dir = Instance('IPython.core.profiledir.ProfileDir')
     shell_socket = Instance('zmq.Socket')
     iopub_socket = Instance('zmq.Socket')
     stdin_socket = Instance('zmq.Socket')
@@ -106,7 +107,9 @@ class Kernel(Configurable):
         atexit.register(self._at_shutdown)
 
         # Initialize the InteractiveShell subclass
-        self.shell = ZMQInteractiveShell.instance(config=self.config)
+        self.shell = ZMQInteractiveShell.instance(config=self.config,
+            profile_dir = self.profile_dir,
+        )
         self.shell.displayhook.session = self.session
         self.shell.displayhook.pub_socket = self.iopub_socket
         self.shell.display_pub.session = self.session
@@ -739,16 +742,16 @@ class IPKernelApp(KernelApp, InteractiveShellApp):
         self.init_code()
 
     def init_kernel(self):
-        kernel_factory = Kernel
 
         if self.pylab:
             gui, backend = pylabtools.find_gui_and_backend(self.pylab)
 
-        kernel = kernel_factory(config=self.config, session=self.session,
+        kernel = Kernel(config=self.config, session=self.session,
                                 shell_socket=self.shell_socket,
                                 iopub_socket=self.iopub_socket,
                                 stdin_socket=self.stdin_socket,
                                 log=self.log,
+                                profile_dir=self.profile_dir,
         )
         self.kernel = kernel
         kernel.record_ports(self.ports)


### PR DESCRIPTION
also add missing shell.profile_dir in ipkernel, though
this value should have no effect.

closes gh-939
