### PR TITLE
temporary theme switcher

### DIFF
--- a/IPython/html/static/notebook/less/terminal.less
+++ b/IPython/html/static/notebook/less/terminal.less
@@ -1,10 +1,10 @@
 .terminal {
   float: left;
   border: black solid 5px;
-  font-family: "DejaVu Sans Mono", "Liberation Mono", monospace;
-  font-size: 11px;
+  font-family: @font-family-monospace;
   color: white;
   background: black;
+  font-size: 14px;
 }
 
 .terminal-cursor {

--- a/IPython/html/static/style/style.min.css
+++ b/IPython/html/static/style/style.min.css
@@ -10612,10 +10612,10 @@ span#autosave_status {
 .terminal {
   float: left;
   border: black solid 5px;
-  font-family: "DejaVu Sans Mono", "Liberation Mono", monospace;
-  font-size: 11px;
+  font-family: monospace;
   color: white;
   background: black;
+  font-size: 14px;
 }
 .terminal-cursor {
   color: black;

--- a/IPython/html/templates/terminal.html
+++ b/IPython/html/templates/terminal.html
@@ -59,4 +59,42 @@ data-ws-path="{{ws_path}}"
     {{super()}}
 
 <script src="{{ static_url("terminal/js/main.js") }}" type="text/javascript" charset="utf-8"></script>
+<script type="text/javascript" charset="utf-8">
+
+    require(['jquery'],function($){
+     var switchfgbg = function(){
+            var sel = '.terminal';
+            this.theme = !this.theme;
+            var theme ={ 
+            false: {
+                bg:'black',
+                fg:'rgb(240, 240, 240)'
+                },
+            true: {
+                bg:'white',
+                fg:'black'
+                }
+            }
+        
+            $(sel).css('border-color',theme[this.theme].bg)
+            $(sel).css('background-color',theme[this.theme].bg)
+            $(sel).css('color',theme[this.theme].fg)
+
+    }
+
+    var sw = function(){
+        switchfgbg('.terminal')
+    }
+    $('#header>.container').append($('<button>').addClass('fa fa-adjust').attr('style','margin-top:14px').on('click',sw))
+    })
+
+</script>
+<style>
+.terminal-cursor {
+    background: gray;
+    font-size: 14px;
+}
+
+</style>
+
 {% endblock %}


### PR DESCRIPTION
Temporary theme switcher requested by @fperez. 

(commit ment to nof end in the final PR, so sloppy)

Make cursor gray 50%, because it is painful to change dynamically.
Also set font/fontsize identical to codemirror.

I still see a 1.5 pixel gap between each lines.

![capture d ecran 2014-10-15 a 13 18 21](https://cloud.githubusercontent.com/assets/335567/4644575/479a23d6-545d-11e4-8128-f01f34d04b37.png)
![capture d ecran 2014-10-15 a 13 18 28](https://cloud.githubusercontent.com/assets/335567/4644576/47a61b1e-545d-11e4-9ac3-83539a444d85.png)
