### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/IPython/core/tests/test_oinspect.py
+++ b/IPython/core/tests/test_oinspect.py
@@ -427,8 +427,5 @@ def test_init_colors():
 def test_builtin_init():
     info = inspector.info(list)
     init_def = info['init_definition']
-    # Python < 3.4 can't get init definition from builtins,
-    # but still exercise the inspection in case of error-raising bugs.
-    if sys.version_info >= (3,4):
-        nt.assert_is_not_none(init_def)
+    nt.assert_is_not_none(init_def)
 

--- a/IPython/external/qt_loaders.py
+++ b/IPython/external/qt_loaders.py
@@ -109,47 +109,6 @@ def loaded_api():
 def has_binding(api):
     """Safely check for PyQt4/5, PySide or PySide2, without importing submodules
 
-    Supports Python <= 3.3
-
-       Parameters
-       ----------
-       api : str [ 'pyqtv1' | 'pyqt' | 'pyqt5' | 'pyside' | 'pyside2' | 'pyqtdefault']
-            Which module to check for
-
-       Returns
-       -------
-       True if the relevant module appears to be importable
-    """
-    # we can't import an incomplete pyside and pyqt4
-    # this will cause a crash in sip (#1431)
-    # check for complete presence before importing
-    module_name = api_to_module[api]
-
-    import imp
-    try:
-        #importing top level PyQt4/PySide module is ok...
-        mod = import_module(module_name)
-        #...importing submodules is not
-        imp.find_module('QtCore', mod.__path__)
-        imp.find_module('QtGui', mod.__path__)
-        imp.find_module('QtSvg', mod.__path__)
-        if api in (QT_API_PYQT5, QT_API_PYSIDE2):
-            # QT5 requires QtWidgets too
-            imp.find_module('QtWidgets', mod.__path__)
-
-        #we can also safely check PySide version
-        if api == QT_API_PYSIDE:
-            return check_version(mod.__version__, '1.0.3')
-        else:
-            return True
-    except ImportError:
-        return False
-
-def has_binding_new(api):
-    """Safely check for PyQt4/5, PySide or PySide2, without importing submodules
-
-    Supports Python >= 3.4
-
         Parameters
         ----------
         api : str [ 'pyqtv1' | 'pyqt' | 'pyqt5' | 'pyside' | 'pyside2' | 'pyqtdefault']
@@ -185,8 +144,6 @@ def has_binding_new(api):
 
     return True
 
-if sys.version_info >= (3, 4):
-    has_binding = has_binding_new
 
 def qtapi_version():
     """Return which QString API has been set, if any

--- a/IPython/utils/tests/test_text.py
+++ b/IPython/utils/tests/test_text.py
@@ -133,13 +133,9 @@ def eval_formatter_no_slicing_check(f):
     
     s = f.format('{stuff[slice(1,4)]}', **ns)
     nt.assert_equal(s, 'ell')
-    
-    if sys.version_info >= (3, 4):
-        # String formatting has changed in Python 3.4, so this now works.
-        s = f.format("{a[:]}", a=[1, 2])
-        nt.assert_equal(s, "[1, 2]")
-    else:
-        nt.assert_raises(SyntaxError, f.format, "{a[:]}")
+
+    s = f.format("{a[:]}", a=[1, 2])
+    nt.assert_equal(s, "[1, 2]")
 
 def test_eval_formatter():
     f = text.EvalFormatter()

--- a/IPython/utils/tokenize2.py
+++ b/IPython/utils/tokenize2.py
@@ -91,11 +91,7 @@ Expfloat = r'[0-9]+' + Exponent
 Floatnumber = group(Pointfloat, Expfloat)
 Imagnumber = group(r'[0-9]+[jJ]', Floatnumber + r'[jJ]')
 Number = group(Imagnumber, Floatnumber, Intnumber)
-
-if sys.version_info.minor >= 3:
-    StringPrefix = r'(?:[bB][rR]?|[rR][bB]?|[uU])?'
-else:
-    StringPrefix = r'(?:[bB]?[rR]?)?'
+StringPrefix = r'(?:[bB][rR]?|[rR][bB]?|[uU])?'
 
 # Tail end of ' string.
 Single = r"[^'\\]*(?:\\.[^'\\]*)*'"
@@ -165,20 +161,19 @@ for t in ("'", '"',
           "bR'", 'bR"', "BR'", 'BR"' ):
     single_quoted[t] = t
 
-if sys.version_info.minor >= 3:
-    # Python 3.3
-    for _prefix in ['rb', 'rB', 'Rb', 'RB', 'u', 'U']:
-        _t2 = _prefix+'"""'
-        endprogs[_t2] = double3prog
-        triple_quoted[_t2] = _t2
-        _t1 = _prefix + "'''"
-        endprogs[_t1] = single3prog
-        triple_quoted[_t1] = _t1
-        single_quoted[_prefix+'"'] = _prefix+'"'
-        single_quoted[_prefix+"'"] = _prefix+"'"
-    del _prefix, _t2, _t1
-    endprogs['u'] = None
-    endprogs['U'] = None
+
+for _prefix in ['rb', 'rB', 'Rb', 'RB', 'u', 'U']:
+    _t2 = _prefix+'"""'
+    endprogs[_t2] = double3prog
+    triple_quoted[_t2] = _t2
+    _t1 = _prefix + "'''"
+    endprogs[_t1] = single3prog
+    triple_quoted[_t1] = _t1
+    single_quoted[_prefix+'"'] = _prefix+'"'
+    single_quoted[_prefix+"'"] = _prefix+"'"
+del _prefix, _t2, _t1
+endprogs['u'] = None
+endprogs['U'] = None
 
 del _compile
 

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,9 @@ contribute to the project.
 
 **IPython versions and Python Support**
 
-**IPython 6** requires Python version 3.3 and above.
+**IPython 6.3** requires Python version 3.4 and above.
+
+**IPython 6.0-6.2** requires Python version 3.3 and above.
 
 **IPython 5.x LTS** is the compatible release for Python 2.7.
 If you require Python 2 support, you **must** use IPython 5.x LTS. Please

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -217,29 +217,30 @@ running, use the ``%connect_info`` magic to get the unique connection file,
 which will be something like ``--existing kernel-19732.json`` but with
 different numbers which correspond to the Process ID of the kernel.
 
-You can read more about using `jupyter qtconsole 
+You can read more about using `jupyter qtconsole
 <http://jupyter.org/qtconsole/>`_, and
 `jupyter notebook <http://jupyter-notebook.readthedocs.io/en/latest/>`_. There
-is also a :ref:`message spec <messaging>` which documents the protocol for 
+is also a :ref:`message spec <messaging>` which documents the protocol for
 communication between kernels
 and clients.
 
 .. seealso::
-    
+
     `Frontend/Kernel Model`_ example notebook
 
 
 Interactive parallel computing
 ==============================
 
-    
+
 This functionality is optional and now part of the `ipyparallel
 <http://ipyparallel.readthedocs.io/>`_ project.
 
 Portability and Python requirements
 -----------------------------------
 
-Version 6.0+ supports compatibility with Python 3.3 and higher.
+Version 6.3+ supports Python 3.4 and higher.
+Versions 6.0 to 6.2 support Python 3.3 and higher.
 Versions 2.0 to 5.x work with Python 2.7.x releases and Python 3.3 and higher.
 Version 1.0 additionally worked with Python 2.6 and 3.2.
 Version 0.12 was the first version to fully support Python 3.

--- a/setup.py
+++ b/setup.py
@@ -199,7 +199,7 @@ install_requires = [
 # but requires pip >= 6. pip < 6 ignores these.
 
 extras_require.update({
-    ':python_version <= "3.4"': ['typing'],
+    ':python_version == "3.4"': ['typing'],
     ':sys_platform != "win32"': ['pexpect'],
     ':sys_platform == "darwin"': ['appnope'],
     ':sys_platform == "win32"': ['colorama'],

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@
 ; tox -- --all -j  # Runs "iptest --all -j" in every environment
 
 [tox]
-envlist = py{36,35,34,33,27,py}
+envlist = py{36,35,34,py}
 skip_missing_interpreters = True
 toxworkdir = /tmp/tox_ipython
 
@@ -19,7 +19,7 @@ toxworkdir = /tmp/tox_ipython
 ; Other IPython/testing dependencies should be in setup.py, not here
 deps =
   pypy: https://bitbucket.org/pypy/numpy/get/master.zip
-  py{36,35,34,33,27}: matplotlib
+  py{36,35,34}: matplotlib
   .[test]
 
 ; It's just to avoid loading the IPython package in the current directory


### PR DESCRIPTION
I found and removed a few more bits of code that supported Python 3.3, and updated some versions in docs.

This is against your req-py34 branch and merging would update your PR against the main repo: https://github.com/ipython/ipython/pull/10833.